### PR TITLE
Dependabot Merge Automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/pypsdm'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check Pre-Release
+        run: |
+          NEW="${{ steps.metadata.outputs.new-version }}"
+          if [[ "$NEW" =~ ([0-9]+!)?[0-9]+(\.[0-9]+)*((a|b|rc)[0-9]*|\.dev[0-9]*) ]]; then
+            echo "::error::Pre-release version ($NEW) detected – workflow stopped."
+            exit 1
+          fi
+
+      - name: Approve the PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add example for Line Results to documentation [#341](https://github.com/ie3-institute/pypsdm/issues/341)
 - Add colored Line Trace to plotting [#348](https://github.com/ie3-institute/pypsdm/issues/348)
 - Add colored Node Trace to plotting [#349](https://github.com/ie3-institute/pypsdm/issues/349)
+- Added Dependabot Patch Merge Automation [#399](https://github.com/ie3-institute/pypsdm/issues/399) 
 
 ### Changed
 - Move `NBVAL` to dev dependencies [#374](https://github.com/ie3-institute/pypsdm/issues/374)


### PR DESCRIPTION
Closes #399 
This pull request introduces automation for merging Dependabot patch updates, streamlining dependency management for the repository. The workflow ensures only patch-level updates from Dependabot are automatically approved and merged, and prevents pre-release versions from being merged.

**Automation for Dependabot patch merges:**

* Added a new GitHub Actions workflow in `.github/workflows/dependabot-auto-merge.yml` to automatically approve and enable auto-merge for Dependabot pull requests that are patch-level semantic version updates.
* The workflow checks for pre-release versions and stops if detected, ensuring only stable releases are merged.

**Documentation update:**

* Documented the addition of Dependabot patch merge automation in `CHANGELOG.md`.